### PR TITLE
C++11 cleanup and unregistering support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([ouroboros], [1.0], [])
-AC_CONFIG_SRCDIR([src/ouroboros/callback.hpp])
+AC_CONFIG_SRCDIR([src/ouroboros/ouroboros_server.h])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror subdir-objects])
 

--- a/src/ouroboros/callback_manager.cpp
+++ b/src/ouroboros/callback_manager.cpp
@@ -38,6 +38,8 @@ namespace ouroboros
 			auto cmp = [aID](const std::pair<std::string, callback_f>& a){ return aID == a.first; };
 			vec.erase(std::find_if(vec.begin(), vec.end(), cmp));
 		}
+		
+		mIdToFields.erase(aID);
 
 		return result;
 	}

--- a/src/ouroboros/callback_manager.cpp
+++ b/src/ouroboros/callback_manager.cpp
@@ -41,4 +41,15 @@ namespace ouroboros
 
 		return result;
 	}
+	
+	callback_manager::~callback_manager()
+	{
+		for (auto& pair : mFieldToCallbacks)
+		{
+			for (auto& pair2 : pair.second)
+			{
+				pair2.second = nullptr;
+			}
+		}
+	}
 }

--- a/src/ouroboros/callback_manager.cpp
+++ b/src/ouroboros/callback_manager.cpp
@@ -1,8 +1,6 @@
 #include <ouroboros/callback_manager.h>
-#include <ouroboros/rest.h>
 #include <ouroboros/data/misc.h>
 
-#include <sstream>
 #include <cstdlib>
 #include <functional>
 #include <algorithm>
@@ -15,7 +13,9 @@ namespace ouroboros
 	:mStore(aStore)
 	{}
 
-	void callback_manager::trigger_callbacks(const std::string& aGroup, const std::string& aField)
+	void callback_manager::trigger_callbacks(
+		const std::string& aGroup,
+		const std::string& aField)
 	{
 		std::string resource = aGroup + '/' + aField;
 		if (mFieldToCallbacks.count(resource))
@@ -37,21 +37,12 @@ namespace ouroboros
 			std::vector<std::pair<std::string, callback_f>>& vec = mFieldToCallbacks[field];
 			auto cmp = [aID](const std::pair<std::string, callback_f>& a){ return aID == a.first; };
 			vec.erase(std::find_if(vec.begin(), vec.end(), cmp));
+			
+			mIdToFields.erase(aID);
 		}
 		
-		mIdToFields.erase(aID);
+
 
 		return result;
-	}
-	
-	callback_manager::~callback_manager()
-	{
-		for (auto& pair : mFieldToCallbacks)
-		{
-			for (auto& pair2 : pair.second)
-			{
-				pair2.second = nullptr;
-			}
-		}
 	}
 }

--- a/src/ouroboros/callback_manager.h
+++ b/src/ouroboros/callback_manager.h
@@ -26,6 +26,7 @@ namespace ouroboros
 		 *	@param [in] aStore Reference to data store with elements to manage.
 		 */
 		callback_manager(data_store<var_field>& aStore);
+		~callback_manager();
 
 		/**	Registers a callback with the given name.
 		 *

--- a/src/ouroboros/callback_manager.h
+++ b/src/ouroboros/callback_manager.h
@@ -26,7 +26,6 @@ namespace ouroboros
 		 *	@param [in] aStore Reference to data store with elements to manage.
 		 */
 		callback_manager(data_store<var_field>& aStore);
-		~callback_manager();
 
 		/**	Registers a callback with the given name.
 		 *

--- a/src/ouroboros/data/base.ipp
+++ b/src/ouroboros/data/base.ipp
@@ -113,21 +113,17 @@ namespace ouroboros
 		result += ", " + base + ", \"contents\" : {";
 		if (!(mGroups.empty() && mItems.empty()))
 		{
-			typedef std::list<std::string>::const_iterator l_iter;
-
-			for (l_iter itr = mInsertOrder.begin();
-				itr != mInsertOrder.end();
-				++itr)
+			for (const std::string& item : mInsertOrder)
 			{
-				if (mGroups.count(*itr))
+				if (mGroups.count(item))
 				{
-					result += " \"" + *itr + "\" : "
-						+ mGroups.find(*itr)->second->getJSON() + ",";
+					result += " \"" + item + "\" : "
+						+ mGroups.find(item)->second->getJSON() + ",";
 				}
-				if (mItems.count(*itr))
+				if (mItems.count(item))
 				{
-					result +=  "\"" + *itr + "\" : "
-						+ mItems.find(*itr)->second->getJSON() + ",";
+					result +=  "\"" + item + "\" : "
+						+ mItems.find(item)->second->getJSON() + ",";
 				}
 			}
 
@@ -145,10 +141,9 @@ namespace ouroboros
 	std::vector<T*> group<T>::getFields() const
 	{
 		std::vector<T*> result;
-		typedef typename std::map<std::string, T*>::const_iterator iter;
-		for (iter itr = mItems.begin(); itr != mItems.end(); ++itr)
+		for (const std::pair<std::string, T*>& pair : mItems)
 		{
-			result.push_back(itr->second);
+			result.push_back(pair.second);
 		}
 		return result;
 	}
@@ -157,10 +152,9 @@ namespace ouroboros
 	std::vector<group<T>*> group<T>::getGroups() const
 	{
 		std::vector<group<T>*> result;
-		typedef typename std::map<std::string, group<T>*>::const_iterator iter;
-		for (iter itr = mGroups.begin(); itr != mGroups.end(); ++itr)
+		for (const std::pair<std::string, group<T>*>& pair : mGroups)
 		{
-			result.push_back(itr->second);
+			result.push_back(pair.second);
 		}
 		return result;
 	}

--- a/src/ouroboros/data/base.ipp
+++ b/src/ouroboros/data/base.ipp
@@ -136,7 +136,7 @@ namespace ouroboros
 		result += " } }";
 		return result;
 	}
-	
+
 	template<class T>
 	std::vector<T*> group<T>::getFields() const
 	{

--- a/src/ouroboros/data/base_number.hpp
+++ b/src/ouroboros/data/base_number.hpp
@@ -107,6 +107,7 @@ namespace ouroboros
 		bool setJSON(const JSON& aJSON);
 
 	private:
+		std::string print_value();
 		std::pair<Number, Number> mRange;
 		Number mValue;
 

--- a/src/ouroboros/data/base_number.ipp
+++ b/src/ouroboros/data/base_number.ipp
@@ -96,14 +96,13 @@ namespace ouroboros
 		{
 			return aNum;
 		}
-		
+
 		int cast_value(char aNum)
 		{
 			return aNum;
 		}
 	}
-	
-	
+
 	template<class Number, Number Min, Number Max>
 	std::string base_number<Number, Min, Max>::getJSON() const
 	{

--- a/src/ouroboros/data/base_number.ipp
+++ b/src/ouroboros/data/base_number.ipp
@@ -79,6 +79,31 @@ namespace ouroboros
 		return mValue;
 	}
 
+	namespace detail
+	{
+		template<class Number>
+		Number cast_value(Number aNum)
+		{
+			return aNum;
+		}
+
+		std::uint16_t cast_value(std::uint8_t aNum)
+		{
+			return aNum;
+		}
+
+		std::int16_t cast_value(std::int8_t aNum)
+		{
+			return aNum;
+		}
+		
+		int cast_value(char aNum)
+		{
+			return aNum;
+		}
+	}
+	
+	
 	template<class Number, Number Min, Number Max>
 	std::string base_number<Number, Min, Max>::getJSON() const
 	{
@@ -123,14 +148,14 @@ namespace ouroboros
 		}
 		ss << "\", ";
 
-		ss << "\"absolute range\" : [ " << Min << ", " << Max << " ], ";
+		ss << "\"absolute range\" : [ " << detail::cast_value(Min) << ", " << detail::cast_value(Max) << " ], ";
 
 		std::string base = var_field::getJSON();
 		base.erase(base.find_first_of('{'), 1);
 		base.erase(base.find_last_of('}'), 1);
 
-		ss << base << ", \"value\" : " << mValue << ", ";
-		ss << "\"range\" : [ " << mRange.first << ", " << mRange.second << " ]";
+		ss << base << ", \"value\" : " << detail::cast_value(mValue) << ", ";
+		ss << "\"range\" : [ " << detail::cast_value(mRange.first) << ", " << detail::cast_value(mRange.second) << " ]";
 		ss << " }";
 
 		return ss.str();;

--- a/src/ouroboros/device_tree.ipp
+++ b/src/ouroboros/device_tree.ipp
@@ -24,7 +24,7 @@ namespace ouroboros
 	{
 		return *mpDataStore;
 	}
-	
+
 	template <class field>
 	function_manager& device_tree<field>::get_function_manager()
 	{

--- a/src/ouroboros/function_manager.cpp
+++ b/src/ouroboros/function_manager.cpp
@@ -2,23 +2,42 @@
 
 #include <vector>
 #include <string>
+#include <algorithm>
 
 namespace ouroboros
 {
-	
+	const std::string function_manager::rand_string("0123456789");
+
 	function_manager::function_manager()
 	{}
-	
+
 	void function_manager::execute_function(
 		const std::string& aFunctionName,
 		const std::vector<std::string>& aParameters)
 	{
-		if (mFunctionCallbacks.count(aFunctionName))
+		if (mNameToFuncs.count(aFunctionName))
 		{
-			for (function_f& func : mFunctionCallbacks[aFunctionName])
+			for (auto& pair : mNameToFuncs[aFunctionName])
 			{
-				func(aParameters);
+				pair.second(aParameters);
 			}
 		}
+	}
+	
+	std::string function_manager::unregister_function(const std::string& aID)
+	{
+		std::string result;
+		
+		if (mIdToName.count(aID))
+		{
+			std::string name = result = mIdToName[aID];
+			std::vector<std::pair<std::string, function_f>>& vec = mNameToFuncs[name];
+			auto cmp = [aID](const std::pair<std::string, function_f>& a){ return aID == a.first; };
+			vec.erase(std::find_if(vec.begin(), vec.end(), cmp));
+			
+			mIdToName.erase(aID);
+		}
+
+		return result;
 	}
 }

--- a/src/ouroboros/function_manager.cpp
+++ b/src/ouroboros/function_manager.cpp
@@ -15,11 +15,9 @@ namespace ouroboros
 	{
 		if (mFunctionCallbacks.count(aFunctionName))
 		{
-			typedef std::vector<function_f>::const_iterator iter;
-			std::vector<function_f>& vec = mFunctionCallbacks[aFunctionName];
-			for (iter itr = vec.begin(); itr != vec.end(); ++itr)
+			for (function_f& func : mFunctionCallbacks[aFunctionName])
 			{
-				(*itr)(aParameters);
+				func(aParameters);
 			}
 		}
 	}

--- a/src/ouroboros/function_manager.cpp
+++ b/src/ouroboros/function_manager.cpp
@@ -1,4 +1,5 @@
 #include <ouroboros/function_manager.h>
+#include <ouroboros/data/misc.h>
 
 #include <vector>
 #include <string>

--- a/src/ouroboros/function_manager.h
+++ b/src/ouroboros/function_manager.h
@@ -1,6 +1,8 @@
 #ifndef _OUROBOROS_FUNCTION_MANAGER_H_
 #define _OUROBOROS_FUNCTION_MANAGER_H_
 
+#include <ouroboros/data/misc.h>
+
 #include <vector>
 #include <string>
 #include <map>
@@ -19,11 +21,18 @@ namespace ouroboros
 		 *	@param [in] aFunctionName Name of the function to register.
 		 *	@param [in] aResponse Callback functor that is called as
 		 *		void(std::vector<std::string>) function.
-		 *	@returns True upon success, false otherwise.
+		 *	@returns ID string of the registered function. Empty string if
+		 *		failed to register.
 		 */
 		template<typename F>
-		bool register_function(
+		std::string register_function(
 			const std::string& aFunctionName, F&& aResponse);
+		
+		/**	Unregisters a function with the given ID.
+		 *
+		 *	@returns The name of the given function when registered.
+		 */
+		std::string unregister_function(const std::string& aID);
 		
 		/**	Executes a response function for the specified function call.
 		 *
@@ -37,7 +46,10 @@ namespace ouroboros
 		function_manager(const function_manager&) = delete;
 
 	private:
-		std::map<std::string, std::vector<function_f> > mFunctionCallbacks;
+		static const std::string rand_string;
+		
+		std::map<std::string, std::string> mIdToName;
+		std::map<std::string, std::vector<std::pair<std::string, function_f>>> mNameToFuncs;
 	};
 }
 

--- a/src/ouroboros/function_manager.h
+++ b/src/ouroboros/function_manager.h
@@ -33,9 +33,10 @@ namespace ouroboros
 		void execute_function(
 			const std::string& aFunctionName,
 			const std::vector<std::string>& aParameters);
-		
+
+		function_manager(const function_manager&) = delete;
+
 	private:
-		function_manager(const function_manager&);
 		std::map<std::string, std::vector<function_f> > mFunctionCallbacks;
 	};
 }

--- a/src/ouroboros/function_manager.h
+++ b/src/ouroboros/function_manager.h
@@ -1,8 +1,6 @@
 #ifndef _OUROBOROS_FUNCTION_MANAGER_H_
 #define _OUROBOROS_FUNCTION_MANAGER_H_
 
-#include <ouroboros/data/misc.h>
-
 #include <vector>
 #include <string>
 #include <map>

--- a/src/ouroboros/function_manager.ipp
+++ b/src/ouroboros/function_manager.ipp
@@ -1,11 +1,21 @@
 namespace ouroboros
 {
 	template <typename F>
-	bool function_manager::register_function(
+	std::string function_manager::register_function(
 		const std::string& aFunctionName, F&& aResponse)
 	{
-		mFunctionCallbacks[aFunctionName].emplace_back(aResponse);
+		std::string result = aFunctionName;
+		result += ":";
+		result = detail::generate_random_string(result, rand_string, 1);
+		
+		while (mIdToName.count(result))
+		{
+			result = detail::generate_random_string(result, rand_string, 1);
+		}
 
-		return true;
+		mIdToName[result] = aFunctionName;
+		mNameToFuncs[aFunctionName].emplace_back(result, aResponse);
+
+		return result;
 	}
 }

--- a/src/ouroboros/function_manager.ipp
+++ b/src/ouroboros/function_manager.ipp
@@ -1,3 +1,6 @@
+
+#include <ouroboros/data/misc.h>
+
 namespace ouroboros
 {
 	template <typename F>

--- a/src/ouroboros/function_manager.ipp
+++ b/src/ouroboros/function_manager.ipp
@@ -5,7 +5,7 @@ namespace ouroboros
 		const std::string& aFunctionName, F&& aResponse)
 	{
 		mFunctionCallbacks[aFunctionName].emplace_back(aResponse);
-		
+
 		return true;
 	}
 }

--- a/src/ouroboros/main.cpp
+++ b/src/ouroboros/main.cpp
@@ -21,11 +21,12 @@ int main()
 	cout << "Starting Ouroboros...\n";
 
 	std::string plugin_directory("plugin");
-	plugin_manager plugin_manager;
+	
 	ouroboros_server s(8080);
+	plugin_manager plugin_manager(s);
 
 	cout << "\tPlugins loaded : " <<
-		plugin_manager.load_directory(s, plugin_directory) << endl;
+		plugin_manager.load_directory(plugin_directory) << endl;
 	signal(SIGINT, handler);
 
 	run = 1;

--- a/src/ouroboros/main.cpp
+++ b/src/ouroboros/main.cpp
@@ -21,11 +21,11 @@ int main()
 	cout << "Starting Ouroboros...\n";
 
 	std::string plugin_directory("plugin");
+	plugin_manager plugin_manager;
 	ouroboros_server s(8080);
-	plugin_manager plugin_manager(s);
 
 	cout << "\tPlugins loaded : " <<
-		plugin_manager.load_directory(plugin_directory) << endl;
+		plugin_manager.load_directory(s, plugin_directory) << endl;
 	signal(SIGINT, handler);
 
 	run = 1;

--- a/src/ouroboros/ouroboros_server.cpp
+++ b/src/ouroboros/ouroboros_server.cpp
@@ -377,12 +377,15 @@ namespace ouroboros
 
 
 
-	void ouroboros_server::unregister_callback(const std::string&)
+	void ouroboros_server::unregister_callback(const std::string& aID)
 	{
-		//TODO
+		mCallbackManager.unregister_callback(aID);
 	}
 	
-	
+	void ouroboros_server::unregister_function(const std::string& aID)
+	{
+		mFunctionManager.unregister_function(aID);
+	}
 	
 	void ouroboros_server::execute_function(const std::string& aFunctionName, const std::vector<std::string>& aParameters)
 	{

--- a/src/ouroboros/ouroboros_server.h
+++ b/src/ouroboros/ouroboros_server.h
@@ -101,7 +101,7 @@ namespace ouroboros
 		std::string register_callback(
 			const std::string& aGroup,
 			const std::string& aField,
-			F aCallback);
+			F&& aCallback);
 
 		/**	Registers a response function for the specified function call.
 		 *
@@ -111,7 +111,7 @@ namespace ouroboros
 		 *	@returns True upon success, false otherwise.
 		 */
 		template <typename F>
-		bool register_function(const std::string& aFunctionName, F aResponse);
+		bool register_function(const std::string& aFunctionName, F&& aResponse);
 
 		/**	Executes a response function for the specified function call.
 		 *
@@ -154,8 +154,6 @@ namespace ouroboros
 
 		static int event_handler(mg_connection *conn, mg_event ev);
 		static std::string normalize_group(const std::string& aGroup);
-
-
 
 		mg_server *mpServer;
 		device_tree<var_field> mTree;

--- a/src/ouroboros/ouroboros_server.h
+++ b/src/ouroboros/ouroboros_server.h
@@ -126,6 +126,13 @@ namespace ouroboros
 		 *
 		 */
 		void unregister_callback(const std::string& aID);
+		
+		//@{
+		//Do not allow for the server to be copyable nor allow for it to be
+		//assigned to anything else.
+		ouroboros_server(const ouroboros_server&) = delete;
+		ouroboros_server& operator=(const ouroboros_server&) = delete;
+		//@}
 
 	private:
 
@@ -142,18 +149,13 @@ namespace ouroboros
 			const std::string& aGroup, const std::string& aField);
 
 		static ouroboros_server *mpSendServer;
-		static void establish_connection(var_field* aResponse);
+		static void establish_connection(ouroboros_server& aServer, var_field* aResponse);
 		void send_response(mg_connection* aConn);
 
 		static int event_handler(mg_connection *conn, mg_event ev);
 		static std::string normalize_group(const std::string& aGroup);
 
-		//@{
-		//Do not allow for the server to be copyable nor allow for it to be
-		//assigned to anything else.
-		ouroboros_server(const ouroboros_server&);
-		ouroboros_server& operator=(const ouroboros_server&);
-		//@}
+
 
 		mg_server *mpServer;
 		device_tree<var_field> mTree;

--- a/src/ouroboros/ouroboros_server.h
+++ b/src/ouroboros/ouroboros_server.h
@@ -103,6 +103,13 @@ namespace ouroboros
 			const std::string& aField,
 			F&& aCallback);
 
+		/**	Unregisters a callback function for the specified element.
+		 *
+		 *	@param [in] aID String describing the ID of the callback.
+		 *
+		 */
+		void unregister_callback(const std::string& aID);
+		
 		/**	Registers a response function for the specified function call.
 		 *
 		 *	@param [in] aFunctionName Name of the function to register.
@@ -111,7 +118,15 @@ namespace ouroboros
 		 *	@returns True upon success, false otherwise.
 		 */
 		template <typename F>
-		bool register_function(const std::string& aFunctionName, F&& aResponse);
+		std::string register_function(
+			const std::string& aFunctionName, F&& aResponse);
+
+		/**	Unregisters a function callback.
+		 *
+		 *	@param [in] aID String describing the ID of the callback.
+		 *
+		 */
+		void unregister_function(const std::string& aID);
 
 		/**	Executes a response function for the specified function call.
 		 *
@@ -120,12 +135,7 @@ namespace ouroboros
 		 */
 		void execute_function(const std::string& aFunctionName, const std::vector<std::string>& aParameters);
 
-		/**	Unregisters a callback function for the specified element.
-		 *
-		 *	@param [in] aID String describing the ID of the callback.
-		 *
-		 */
-		void unregister_callback(const std::string& aID);
+
 		
 		//@{
 		//Do not allow for the server to be copyable nor allow for it to be

--- a/src/ouroboros/ouroboros_server.h
+++ b/src/ouroboros/ouroboros_server.h
@@ -115,7 +115,9 @@ namespace ouroboros
 		 *	@param [in] aFunctionName Name of the function to register.
 		 *	@param [in] aResponse Callback functor that is called as
 		 * 		void(std::vector<std::string>) function.
-		 *	@returns True upon success, false otherwise.
+		 *
+		 *	@returns A unique string ID representing the function registration,
+		 *		or an empty string in case of a failure.
 		 */
 		template <typename F>
 		std::string register_function(
@@ -123,7 +125,7 @@ namespace ouroboros
 
 		/**	Unregisters a function callback.
 		 *
-		 *	@param [in] aID String describing the ID of the callback.
+		 *	@param [in] aID String describing the ID of the function.
 		 *
 		 */
 		void unregister_function(const std::string& aID);
@@ -133,10 +135,10 @@ namespace ouroboros
 		 *	@param [in] aFunctionName Name of the function to call.
 		 *	@param [in] aParameters Parameters as strings in a vector.
 		 */
-		void execute_function(const std::string& aFunctionName, const std::vector<std::string>& aParameters);
+		void execute_function(
+			const std::string& aFunctionName,
+			const std::vector<std::string>& aParameters);
 
-
-		
 		//@{
 		//Do not allow for the server to be copyable nor allow for it to be
 		//assigned to anything else.
@@ -158,7 +160,6 @@ namespace ouroboros
 		void handle_notification(
 			const std::string& aGroup, const std::string& aField);
 
-		static ouroboros_server *mpSendServer;
 		static void establish_connection(ouroboros_server& aServer, var_field* aResponse);
 		void send_response(mg_connection* aConn);
 
@@ -170,7 +171,6 @@ namespace ouroboros
 		data_store<var_field>& mStore;
 
 		function_manager &mFunctionManager;
-
 		callback_manager mCallbackManager;
 
 		std::map<var_field *, std::string> mResponseUrls;

--- a/src/ouroboros/ouroboros_server.ipp
+++ b/src/ouroboros/ouroboros_server.ipp
@@ -11,7 +11,7 @@ namespace ouroboros
 	}
 
 	template <typename F>
-	bool ouroboros_server::register_function(const std::string& aFunctionName, F&& aResponse)
+	std::string ouroboros_server::register_function(const std::string& aFunctionName, F&& aResponse)
 	{
 		return mFunctionManager.register_function(aFunctionName, aResponse);
 	}

--- a/src/ouroboros/ouroboros_server.ipp
+++ b/src/ouroboros/ouroboros_server.ipp
@@ -4,14 +4,14 @@ namespace ouroboros
 	std::string ouroboros_server::register_callback(
 		const std::string& aGroup,
 		const std::string& aField,
-		F aCallback)
+		F&& aCallback)
 	{
 		std::string result = mCallbackManager.register_callback(normalize_group(aGroup), aField, aCallback);
 		return result;
 	}
 
 	template <typename F>
-	bool ouroboros_server::register_function(const std::string& aFunctionName, F aResponse)
+	bool ouroboros_server::register_function(const std::string& aFunctionName, F&& aResponse)
 	{
 		return mFunctionManager.register_function(aFunctionName, aResponse);
 	}

--- a/src/ouroboros/plugin.h
+++ b/src/ouroboros/plugin.h
@@ -7,6 +7,7 @@ namespace ouroboros
 {
 	//Defines the type of function that plugins must support.
 	typedef bool (*plugin_entry_function)(ouroboros_server& aServer);
+	typedef void (*plugin_exit_function)(ouroboros_server& aServer);
 
 	/**	Function called by a plugin manager upon loading the plugin.
 	 *
@@ -29,7 +30,26 @@ namespace ouroboros
 	 */
 	extern "C" bool plugin_entry(ouroboros_server& aServer);
 
-	//TODO implement an unload function
+	/**	Function called by a plugin manager upon unloading the plugin.
+	 *
+	 *	This function is called by a plugin manager when unloading the loaded
+	 *	plugin. Plugin designers are free to execute any code they wish in this
+	 *	function, but be advised that it is likely that blocking in this
+	 *	function will make the entire program hang. As a result, it is advised
+	 *	to make the code that executes here simple. Any resources registered by
+	 *	the plugin MUST be unloaded/unregistered. This includes functions
+	 *	registered with the server.
+	 *
+	 *	Another aspect to note is that the working directory of the plugins
+	 *	will be that of the server, not where they are located relative to the
+	 *	server.
+	 *
+	 *	@param [in] aServer A reference to the server object passed in by the
+	 *		plugin manager. All public methods defined by the server are
+	 *		accessible.
+	 */
+	extern "C" void plugin_exit(ouroboros_server& aServer);
+
 }
 
 #endif//_OUROBOROS_PLUGIN_H_

--- a/src/ouroboros/plugin/Makefile
+++ b/src/ouroboros/plugin/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-Wall -Wextra -pedantic -I. -I../ -I../data -I../../ -std=c++11 -I../../../lib/ -g
+CXXFLAGS=-Wall -Wextra -pedantic -I. -I../ -I../data -I../../ -std=c++11 -I../../../lib/ -g O0
 
 .PHONY: clean all
 

--- a/src/ouroboros/plugin/Makefile
+++ b/src/ouroboros/plugin/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-Wall -Wextra -pedantic -I. -I../ -I../data -I../../ -std=c++11 -I../../../lib/ -g O0
+CXXFLAGS=-Wall -Wextra -pedantic -I. -I../ -I../data -I../../ -std=c++11 -I../../../lib/ -g -O0
 
 .PHONY: clean all
 

--- a/src/ouroboros/plugin/Makefile
+++ b/src/ouroboros/plugin/Makefile
@@ -8,14 +8,14 @@ PYTHON_VERSION ?= 2.7
 all: $(OUTPUT)
 
 python_inline.plugin: sample_python_inline.cpp
-	g++ $(CXXFLAGS)  -fPIC -shared $< -o $@ $(shell pkg-config --cflags --libs python-$(PYTHON_VERSION))
+	$(CXX) $(CXXFLAGS)  -fPIC -shared $< -o $@ $(shell pkg-config --cflags --libs python-$(PYTHON_VERSION))
 
 python_file.plugin: sample_python_file.cpp
-	g++ $(CXXFLAGS)  -fPIC -shared $< -o $@ $(shell pkg-config --cflags --libs python-$(PYTHON_VERSION))
+	$(CXX) $(CXXFLAGS)  -fPIC -shared $< -o $@ $(shell pkg-config --cflags --libs python-$(PYTHON_VERSION))
 
 
 sample_cpp.plugin: sample_cpp.cpp
-	g++ $(CXXFLAGS) -fPIC -shared $< -o $@
+	$(CXX) $(CXXFLAGS) -fPIC -shared $< -o $@
 
 clean:
 	rm -rf $(OUTPUT) *.o

--- a/src/ouroboros/plugin/sample_cpp.cpp
+++ b/src/ouroboros/plugin/sample_cpp.cpp
@@ -16,13 +16,16 @@ void func(const std::vector<std::string>& aParams)
 	std::cout << aParams[0] << " " << aParams[1] << endl;
 }
 
+static std::string c_id;
+static std::string f_id;
+
 extern "C" bool plugin_entry(ouroboros_server& aServer)
 {
 	cout << "Initializing plugin..." << endl;
 
-	aServer.register_callback("home", "a_number", ::callback);
+	c_id = aServer.register_callback("home", "a_number", ::callback);
 
-	aServer.register_function("func", ::func);
+	f_id = aServer.register_function("func", ::func);
 	
 	cout << "Done initializing." << endl;
 	return true;
@@ -30,6 +33,7 @@ extern "C" bool plugin_entry(ouroboros_server& aServer)
 
 extern "C" void plugin_exit(ouroboros_server& aServer)
 {
-	
+	aServer.unregister_callback(c_id);
+	aServer.unregister_function(f_id);
 }
 

--- a/src/ouroboros/plugin/sample_cpp.cpp
+++ b/src/ouroboros/plugin/sample_cpp.cpp
@@ -28,3 +28,8 @@ extern "C" bool plugin_entry(ouroboros_server& aServer)
 	return true;
 }
 
+extern "C" void plugin_exit(ouroboros_server& aServer)
+{
+	
+}
+

--- a/src/ouroboros/plugin_manager.cpp
+++ b/src/ouroboros/plugin_manager.cpp
@@ -9,102 +9,111 @@
 #include <climits>
 #include <cstdlib>
 
-using namespace ouroboros;
-
-plugin_manager::plugin_manager()
-{}
-
-plugin_manager::~plugin_manager()
+namespace ouroboros
 {
-	for (auto& pair : mPlugins)
+
+	namespace detail
 	{
-		unload(pair.first);
-	}
-}
-
-bool plugin_manager::unload(const std::string& aPath)
-{
-	if (mPlugins.count(aPath))
-	{
-		dlclose(mPlugins[aPath]);
-		return true;
-	}
-	return false;
-}
-
-bool plugin_manager::load(ouroboros_server& aServer, const std::string& aPath)
-{
-	typedef void* library_t;
-	std::string fullPath(aPath);
-
-	library_t lib = dlopen(fullPath.c_str(), RTLD_NOW);
-
-	const char *err = dlerror();
-	if (err)
-	{
-		return false;
-	}
-
-	//HACK:
-	//This is a hackish way to ward off undefined behavior caused by dlsym.
-	//In short, POSIX requires conversions between object pointers and
-	//function pointers to be possible, while the C and C++ ISO standards
-	//do not. As a result, a simple cast is insuficcient. On the plus side,
-	//newer POSIX standard require that this conversion be supported in order
-	//for a system to be POSIX compliant, so any systems that can use dlsym
-	//support this conversion.
-	plugin_entry_function plugin;
-	*(void **) (&plugin) = dlsym(lib, "plugin_entry");
-	if ((err = dlerror()))
-	{
-		return false;
-	}
-
-	mPlugins[fullPath] = lib;
-	return plugin(aServer);
-}
-
-static std::set<std::string> list_files(const std::string& aDir)
-{
-	std::set<std::string> results;
-	char abs_path[PATH_MAX];
-
-	realpath(aDir.c_str(), abs_path);
-	std::string directory(abs_path);
-	directory += '/';
-
-	DIR *d = opendir(abs_path);
-
-	if (d)
-	{
-		dirent *dir;
-		while ((dir = readdir(d)) != NULL)
+		class plugin
 		{
-			if (realpath((directory + dir->d_name).c_str(), abs_path))
+		public:
+			plugin(void *aLib);
+		private:
+			plugin_entry_function mEntry;
+			plugin_exit_function mExit;
+		};
+	}
+
+	plugin_manager::plugin_manager()
+	{}
+
+	plugin_manager::~plugin_manager()
+	{
+		for (auto& pair : mPlugins)
+		{
+			unload(pair.first);
+		}
+	}
+
+	bool plugin_manager::unload(const std::string& aPath)
+	{
+		return false;
+	}
+
+	bool plugin_manager::load(ouroboros_server& aServer, const std::string& aPath)
+	{//TODO Check that both functions are available
+		typedef void* library_t;
+		std::string fullPath(aPath);
+
+		library_t lib = dlopen(fullPath.c_str(), RTLD_NOW);
+
+		const char *err = dlerror();
+		if (err)
+		{
+			return false;
+		}
+
+		//HACK:
+		//This is a hackish way to ward off undefined behavior caused by dlsym.
+		//In short, POSIX requires conversions between object pointers and
+		//function pointers to be possible, while the C and C++ ISO standards
+		//do not. As a result, a simple cast is insuficcient. On the plus side,
+		//newer POSIX standard require that this conversion be supported in order
+		//for a system to be POSIX compliant, so any systems that can use dlsym
+		//support this conversion.
+		plugin_entry_function plugin;
+		*(void **) (&plugin) = dlsym(lib, "plugin_entry");
+		if ((err = dlerror()))
+		{
+			return false;
+		}
+
+		mPlugins[fullPath] = lib;
+		return plugin(aServer);
+	}
+
+	static std::set<std::string> list_files(const std::string& aDir)
+	{
+		std::set<std::string> results;
+		char abs_path[PATH_MAX];
+
+		realpath(aDir.c_str(), abs_path);
+		std::string directory(abs_path);
+		directory += '/';
+
+		DIR *d = opendir(abs_path);
+
+		if (d)
+		{
+			dirent *dir;
+			while ((dir = readdir(d)) != NULL)
 			{
-				results.insert(abs_path);
+				if (realpath((directory + dir->d_name).c_str(), abs_path))
+				{
+					results.insert(abs_path);
+				}
+			}
+			closedir(d);
+		}
+		return results;
+	}
+
+	//TODO document the fact that loading will only load one plugin per absolute
+	//Path, so symlinks to the same place will not be counted twice
+
+	std::size_t plugin_manager::load_directory(ouroboros_server& aServer, const std::string& aDirectory)
+	{
+		std::size_t number_loaded = 0;
+		std::set<std::string> files(list_files(aDirectory));
+
+		if (!files.empty())
+		{
+			for (const std::string& file : files)
+			{
+				number_loaded += load(aServer, file);
 			}
 		}
-		closedir(d);
+		return number_loaded;
 	}
-	return results;
-}
-
-//TODO document the fact that loading will only load one plugin per absolute
-//Path, so symlinks to the same place will not be counted twice
-
-std::size_t plugin_manager::load_directory(ouroboros_server& aServer, const std::string& aDirectory)
-{
-	std::size_t number_loaded = 0;
-	std::set<std::string> files(list_files(aDirectory));
-
-	if (!files.empty())
-	{
-		for (const std::string& file : files)
-		{
-			number_loaded += load(aServer, file);
-		}
-	}
-	return number_loaded;
 }
 

--- a/src/ouroboros/plugin_manager.cpp
+++ b/src/ouroboros/plugin_manager.cpp
@@ -11,16 +11,14 @@
 
 using namespace ouroboros;
 
-plugin_manager::plugin_manager(ouroboros_server& aServer)
-:mServer(aServer)
+plugin_manager::plugin_manager()
 {}
 
 plugin_manager::~plugin_manager()
 {
-	typedef std::map<std::string, void*>::const_iterator citerator;
-	for (citerator itr = mPlugins.begin(); itr != mPlugins.end(); itr++)
+	for (auto& pair : mPlugins)
 	{
-		unload(itr->first);
+		unload(pair.first);
 	}
 }
 
@@ -34,7 +32,7 @@ bool plugin_manager::unload(const std::string& aPath)
 	return false;
 }
 
-bool plugin_manager::load(const std::string& aPath)
+bool plugin_manager::load(ouroboros_server& aServer, const std::string& aPath)
 {
 	typedef void* library_t;
 	std::string fullPath(aPath);
@@ -63,7 +61,7 @@ bool plugin_manager::load(const std::string& aPath)
 	}
 
 	mPlugins[fullPath] = lib;
-	return plugin(mServer);
+	return plugin(aServer);
 }
 
 static std::set<std::string> list_files(const std::string& aDir)
@@ -95,17 +93,16 @@ static std::set<std::string> list_files(const std::string& aDir)
 //TODO document the fact that loading will only load one plugin per absolute
 //Path, so symlinks to the same place will not be counted twice
 
-std::size_t plugin_manager::load_directory(const std::string& aDirectory)
+std::size_t plugin_manager::load_directory(ouroboros_server& aServer, const std::string& aDirectory)
 {
 	std::size_t number_loaded = 0;
 	std::set<std::string> files(list_files(aDirectory));
 
 	if (!files.empty())
 	{
-		typedef std::set<std::string>::const_iterator citerator;
-		for (citerator itr = files.begin(); itr != files.end(); ++itr)
+		for (const std::string& file : files)
 		{
-			number_loaded += load(*itr);
+			number_loaded += load(aServer, file);
 		}
 	}
 	return number_loaded;

--- a/src/ouroboros/plugin_manager.cpp
+++ b/src/ouroboros/plugin_manager.cpp
@@ -9,102 +9,173 @@
 #include <climits>
 #include <cstdlib>
 
-using namespace ouroboros;
-
-plugin_manager::plugin_manager()
-{}
-
-plugin_manager::~plugin_manager()
+namespace ouroboros
 {
-	for (auto& pair : mPlugins)
+
+	class plugin
 	{
-		unload(pair.first);
-	}
-}
-
-bool plugin_manager::unload(const std::string& aPath)
-{
-	if (mPlugins.count(aPath))
+	public:
+		plugin(ouroboros_server& aServer, void *aLib);
+		bool is_valid() const;
+		bool load();
+		void* unload();
+		
+		plugin(const plugin&) = delete;
+		plugin(plugin&&) = default;
+	private:
+		void *mLib;
+		ouroboros_server& mServer;
+		plugin_entry_function mEntry;
+		plugin_exit_function mExit;
+	};
+	
+	plugin::plugin(ouroboros_server& aServer, void* aLib)
+	:mLib(aLib), mServer(aServer), mEntry(nullptr), mExit(nullptr)
 	{
-		dlclose(mPlugins[aPath]);
-		return true;
-	}
-	return false;
-}
-
-bool plugin_manager::load(ouroboros_server& aServer, const std::string& aPath)
-{
-	typedef void* library_t;
-	std::string fullPath(aPath);
-
-	library_t lib = dlopen(fullPath.c_str(), RTLD_NOW);
-
-	const char *err = dlerror();
-	if (err)
-	{
-		return false;
-	}
-
-	//HACK:
-	//This is a hackish way to ward off undefined behavior caused by dlsym.
-	//In short, POSIX requires conversions between object pointers and
-	//function pointers to be possible, while the C and C++ ISO standards
-	//do not. As a result, a simple cast is insuficcient. On the plus side,
-	//newer POSIX standard require that this conversion be supported in order
-	//for a system to be POSIX compliant, so any systems that can use dlsym
-	//support this conversion.
-	plugin_entry_function plugin;
-	*(void **) (&plugin) = dlsym(lib, "plugin_entry");
-	if ((err = dlerror()))
-	{
-		return false;
-	}
-
-	mPlugins[fullPath] = lib;
-	return plugin(aServer);
-}
-
-static std::set<std::string> list_files(const std::string& aDir)
-{
-	std::set<std::string> results;
-	char abs_path[PATH_MAX];
-
-	realpath(aDir.c_str(), abs_path);
-	std::string directory(abs_path);
-	directory += '/';
-
-	DIR *d = opendir(abs_path);
-
-	if (d)
-	{
-		dirent *dir;
-		while ((dir = readdir(d)) != NULL)
+		//HACK:
+		//This is a hackish way to ward off undefined behavior caused by dlsym.
+		//In short, POSIX requires conversions between object pointers and
+		//function pointers to be possible, while the C and C++ ISO standards
+		//do not. As a result, a simple cast is insuficcient. On the plus side,
+		//newer POSIX standard require that this conversion be supported in order
+		//for a system to be POSIX compliant, so any systems that can use dlsym
+		//support this conversion.
+		char *err;
+		*(void **) (&mEntry) = dlsym(aLib, "plugin_entry");
+		if ((err = dlerror()))
 		{
-			if (realpath((directory + dir->d_name).c_str(), abs_path))
+			mEntry = nullptr;
+		}
+		
+		//HACK:
+		//This is a hackish way to ward off undefined behavior caused by dlsym.
+		//In short, POSIX requires conversions between object pointers and
+		//function pointers to be possible, while the C and C++ ISO standards
+		//do not. As a result, a simple cast is insuficcient. On the plus side,
+		//newer POSIX standard require that this conversion be supported in order
+		//for a system to be POSIX compliant, so any systems that can use dlsym
+		//support this conversion.
+		*(void **) (&mExit) = dlsym(aLib, "plugin_exit");
+		if ((err = dlerror()))
+		{
+			mExit = nullptr;
+		}
+	}
+	
+	bool plugin::is_valid() const
+	{
+		return mEntry && mExit;
+	}
+	
+	bool plugin::load()
+	{
+		if (is_valid())
+		{
+			return mEntry(mServer);
+		}
+		return false;
+	}
+	
+	void* plugin::unload()
+	{
+		if (is_valid())
+		{
+			mExit(mServer);
+			return mLib;
+		}
+		return nullptr;
+	}
+
+
+	plugin_manager::plugin_manager(ouroboros_server& aServer)
+	:mServer(aServer)
+	{}
+
+	plugin_manager::~plugin_manager()
+	{
+		for (auto& pair : mPlugins)
+		{
+			unload(pair.first);
+		}
+	}
+
+	bool plugin_manager::unload(const std::string& aPath)
+	{
+		if (mPlugins.count(aPath))
+		{
+			void *lib = mPlugins.at(aPath).unload();
+			dlclose(lib);
+			return true;
+		}
+		return false;
+	}
+
+	bool plugin_manager::load(const std::string& aPath)
+	{//TODO Check that both functions are available
+		typedef void* library_t;
+		std::string fullPath(aPath);
+
+		library_t lib = dlopen(fullPath.c_str(), RTLD_NOW);
+
+		const char *err = dlerror();
+		if (err)
+		{
+			return false;
+		}
+
+		plugin pl(mServer, lib);
+		
+		if (!pl.is_valid())
+		{
+			return false;
+		}
+
+		mPlugins.emplace(fullPath, std::move(pl));
+		return pl.load();
+	}
+
+	static std::set<std::string> list_files(const std::string& aDir)
+	{
+		std::set<std::string> results;
+		char abs_path[PATH_MAX];
+
+		realpath(aDir.c_str(), abs_path);
+		std::string directory(abs_path);
+		directory += '/';
+
+		DIR *d = opendir(abs_path);
+
+		if (d)
+		{
+			dirent *dir;
+			while ((dir = readdir(d)) != NULL)
 			{
-				results.insert(abs_path);
+				if (realpath((directory + dir->d_name).c_str(), abs_path))
+				{
+					results.insert(abs_path);
+				}
+			}
+			closedir(d);
+		}
+		return results;
+	}
+
+	//TODO document the fact that loading will only load one plugin per absolute
+	//Path, so symlinks to the same place will not be counted twice
+
+	std::size_t plugin_manager::load_directory(const std::string& aDirectory)
+	{
+		std::size_t number_loaded = 0;
+		std::set<std::string> files(list_files(aDirectory));
+
+		if (!files.empty())
+		{
+			for (const std::string& file : files)
+			{
+				number_loaded += load(file);
 			}
 		}
-		closedir(d);
+		return number_loaded;
 	}
-	return results;
-}
-
-//TODO document the fact that loading will only load one plugin per absolute
-//Path, so symlinks to the same place will not be counted twice
-
-std::size_t plugin_manager::load_directory(ouroboros_server& aServer, const std::string& aDirectory)
-{
-	std::size_t number_loaded = 0;
-	std::set<std::string> files(list_files(aDirectory));
-
-	if (!files.empty())
-	{
-		for (const std::string& file : files)
-		{
-			number_loaded += load(aServer, file);
-		}
-	}
-	return number_loaded;
 }
 

--- a/src/ouroboros/plugin_manager.h
+++ b/src/ouroboros/plugin_manager.h
@@ -17,7 +17,7 @@ namespace ouroboros
 		 *	@param [in] aServer Server reference to pass to plugins.
 		 *
 		 */
-		plugin_manager(ouroboros_server& aServer);
+		plugin_manager();
 
 		/**	Destructor.
 		 *
@@ -32,12 +32,12 @@ namespace ouroboros
 		 *	@returns True if the plugin loaded, false otherwise.
 		 *
 		 */
-		bool load(const std::string& aPath);
+		bool load(ouroboros_server& aServer, const std::string& aPath);
 
 		/**	Loads the given directory
 		 *
 		 */
-		std::size_t load_directory(const std::string& aDirectory);
+		std::size_t load_directory(ouroboros_server& aServer, const std::string& aDirectory);
 
 		/**	Unloads the given plugin.
 		 *
@@ -50,7 +50,6 @@ namespace ouroboros
 		bool unload(const std::string& aPath);
 
 	private:
-		ouroboros_server& mServer;
 		std::map<std::string, void*> mPlugins;
 	};
 }

--- a/src/ouroboros/plugin_manager.h
+++ b/src/ouroboros/plugin_manager.h
@@ -8,6 +8,8 @@
 
 namespace ouroboros
 {
+	class plugin;
+	
 	class plugin_manager
 	{
 	public:
@@ -17,7 +19,7 @@ namespace ouroboros
 		 *	@param [in] aServer Server reference to pass to plugins.
 		 *
 		 */
-		plugin_manager();
+		plugin_manager(ouroboros_server& aServer);
 
 		/**	Destructor.
 		 *
@@ -32,12 +34,12 @@ namespace ouroboros
 		 *	@returns True if the plugin loaded, false otherwise.
 		 *
 		 */
-		bool load(ouroboros_server& aServer, const std::string& aPath);
+		bool load(const std::string& aPath);
 
 		/**	Loads the given directory
 		 *
 		 */
-		std::size_t load_directory(ouroboros_server& aServer, const std::string& aDirectory);
+		std::size_t load_directory(const std::string& aDirectory);
 
 		/**	Unloads the given plugin.
 		 *
@@ -50,7 +52,8 @@ namespace ouroboros
 		bool unload(const std::string& aPath);
 
 	private:
-		std::map<std::string, void*> mPlugins;
+		ouroboros_server& mServer;
+		std::map<std::string, plugin> mPlugins;
 	};
 }
 

--- a/src/serverconfig.xml
+++ b/src/serverconfig.xml
@@ -8,6 +8,18 @@
 			This is the Home group.
 		</description>
 		
+		<field type="signedByteField">
+			<title>a byte</title>
+			<description>A byte for testing</description>
+			<value>22</value>
+		</field>
+	
+		<field type="unsignedByteField">
+			<title>a byte2</title>
+			<description>A byte for testing</description>
+			<value>25</value>
+		</field>
+
 		<field type="signedIntField">
 			<title>A number</title>
 			<description>


### PR DESCRIPTION
Added ability to unregister callbacks and functions. Due to the way plugin loading works, any registered callback or function must be unregistered in the new exit routine for plugins, called when unloading the plugin from memory.
